### PR TITLE
[Pivot] Token issuance layer — structural hard-stop enforcement (v1)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,6 +5,8 @@ dist/
 build/
 .venv/
 .env
+amr_signing_key.pem
+amr_signing_key.pub
 *.db
 *.db-wal
 *.db-shm

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -62,6 +62,7 @@ tests/
 5. **No network calls** — AMR is a local MCP server. Zero outbound HTTP from tools.
 6. **Chain hash linking** — Every mandate and action log entry is linked via SHA-256 to the previous entry.
 7. **ruff S rules** — Security linting enforced. `ruff check src/` must pass before any commit.
+8. **Algorithm confusion prevention** — EdDSA is hardcoded in both encode and decode. Never accept algorithm=None or RS256 substitution.
 
 ---
 
@@ -105,3 +106,26 @@ uv run python -c "from amr.config import settings; print(settings.server_name)"
 | `verify_mandate` | Check if an agent has an active, non-expired mandate |
 | `log_action` | Log an agent action under an active mandate (append-only, chained) |
 | `get_proof` | Generate a full Proof Pack JSON for a mandate (mandate + actions + integrity) |
+| `issue_action_token` | Issue a signed action token if and only if a valid mandate authorizes the action (hard-stop enforcement) |
+
+---
+
+## Token Issuance Architecture
+
+AMR v1 adds a structural enforcement layer on top of the mandate registry.
+
+**Format:** JWS Compact Serialization (RFC 7515) with Ed25519 signature (EdDSA).
+
+**Key claims:** `jti` (replay prevention), `amr_mandate_id` (which mandate authorized),
+`amr_action_hash` (SHA-256 of canonical action — prevents token reuse for other actions),
+`aud` (audience — consumers must verify this to prevent confusion attacks).
+
+**Replay prevention:** The `issued_tokens` table stores every issued `jti` with its
+expiration. A token for the same `(mandate_id, action_hash)` pair cannot be issued twice
+within the active window. After expiry, re-issuance is allowed.
+
+**Consumer verification contract:** Consumers MUST verify signature, `iss`, `aud`, `exp`,
+`nbf`, and `amr_action_hash`. See `docs/token-issuance-spec.md` for the full specification.
+
+**Key management:** Ed25519 keypair generated on first use, stored at `signing_key_path`
+(default: `amr_signing_key.pem`). Private key excluded from git via `.gitignore`.

--- a/README.md
+++ b/README.md
@@ -22,6 +22,22 @@ Modern AI agent infrastructure covers many concerns — but the legal mandate la
 
 ---
 
+### Structural hard-stop enforcement
+
+AMR does not only record mandates — it enforces them. Agent runtimes must obtain
+a signed action token from AMR before performing any action. The token is issued
+if and only if a valid, non-expired, non-revoked mandate authorizes that specific
+action for that specific agent. No mandate → no token → no action.
+
+Tokens are JWS (RFC 7515) signed with Ed25519 (EdDSA), include replay prevention
+via the `jti` claim and the `issued_tokens` audit table, and carry the exact
+action hash and scope digest they authorize. Consumers verify offline with the
+AMR public key and MUST check `aud`, `exp`, and `amr_action_hash`.
+
+See `docs/token-issuance-spec.md` for the full specification.
+
+---
+
 ## Vision: from registry to enforcement
 
 AMR v0.1 is a **mandate registry** — it stores, verifies, and audits mandates. This is necessary but not sufficient.

--- a/docs/token-issuance-spec.md
+++ b/docs/token-issuance-spec.md
@@ -1,0 +1,57 @@
+# Token Issuance Specification v1.0
+
+## Goal
+Enforce structural hard-stop: no valid mandate → no token → no action.
+
+## Token Format
+JWS Compact Serialization (RFC 7515) with Ed25519 signature (EdDSA).
+Header: {"alg":"EdDSA","typ":"JWT","kid":"<key-id>"}.
+
+## Required Claims
+- `iss` (issuer): "amr://localhost" or configured issuer URI
+- `sub` (subject): agent_id
+- `aud` (audience): runtime/platform identifier where the token will be presented
+- `exp` (expiration): issued_at + configurable lifetime (default 300s)
+- `iat` (issued_at): UTC epoch
+- `nbf` (not before): iat
+- `jti` (JWT ID): UUIDv4, used for replay prevention
+- `amr_mandate_id`: mandate UUID that authorized this token
+- `amr_action_hash`: SHA-256 of the canonical action descriptor
+  (prevents token reuse for other actions)
+- `amr_scope_digest`: SHA-256 of the mandate scope at issuance time
+
+## Replay Prevention
+The `issued_tokens` table stores every issued jti with its expiration.
+A token cannot be issued twice for the same `(mandate_id, action_hash)`
+within the expiration window (idempotency enforced).
+
+Note: `action_hash` does NOT include the mandate_id. The replay
+prevention is keyed on `(mandate_id, action_hash)` in the DB index,
+which correctly handles the case of two mandates for the same agent
+requesting the same action — each gets its own token.
+
+## Offline Verification Contract (for consumers)
+Consumers of the token (agent runtimes, platforms) validate the token
+using the Ed25519 public key, which AMR publishes at a well-known path
+or exposes via config.
+
+Consumers MUST check, in this order:
+1. JWS signature is valid against the AMR public key (algorithm fixed to EdDSA).
+2. `iss` matches the expected AMR issuer URI.
+3. `aud` matches the consumer's own audience identifier
+   (prevents audience confusion attacks — a token for audience A must
+   not be accepted by audience B).
+4. `exp` is in the future AND `nbf` is in the past (with reasonable clock skew).
+5. `amr_action_hash` matches the SHA-256 of the action they are about to perform
+   (canonical JSON form — see _canonical_action_hash in issue_action_token.py).
+
+If any check fails, the consumer MUST reject the token and refuse the action.
+
+## Security Notes
+- Private key is generated once, stored at `settings.signing_key_path`,
+  file permissions 0600 on POSIX.
+- Algorithm is fixed to EdDSA in both encoding and decoding;
+  no algorithm negotiation to prevent confusion attacks.
+- Key rotation: out of scope for v1 (documented as v2 follow-up).
+- Token revocation before expiration: out of scope for v1.
+  Short token lifetime (5 min default) limits revocation window.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -12,6 +12,8 @@ dependencies = [
     "pydantic>=2.7.0",
     "pydantic-settings>=2.3.0",
     "aiosqlite>=0.20.0",
+    "cryptography>=42.0.0",
+    "pyjwt[crypto]>=2.8.0",
 ]
 
 [project.optional-dependencies]

--- a/src/amr/config.py
+++ b/src/amr/config.py
@@ -14,6 +14,12 @@ class Settings(BaseSettings):
     server_name: str = "Agent Mandate Registry"
     server_version: str = "0.1.0"
 
+    # Token issuance
+    signing_key_path: Path = Path("amr_signing_key.pem")
+    public_key_path: Path = Path("amr_signing_key.pub")
+    token_issuer: str = "amr://localhost"  # noqa: S105 — not a password, it's an issuer URI
+    token_lifetime_seconds: int = 300
+
     model_config = {"env_prefix": "AMR_", "env_file": ".env", "extra": "ignore"}
 
 

--- a/src/amr/crypto/signing.py
+++ b/src/amr/crypto/signing.py
@@ -1,0 +1,80 @@
+"""AMR signing key management for Ed25519 token issuance."""
+
+import hashlib
+import os
+import stat
+import sys
+from pathlib import Path
+
+from cryptography.hazmat.primitives import serialization
+from cryptography.hazmat.primitives.asymmetric import ed25519
+
+from amr.config import settings
+
+
+def generate_signing_key(
+    private_key_path: Path | None = None,
+    public_key_path: Path | None = None,
+) -> None:
+    """Generate a new Ed25519 keypair and write it to disk.
+
+    Raises FileExistsError if a key already exists at private_key_path.
+    Sets file permissions to 0600 on POSIX systems. No-op on Windows.
+    """
+    priv_path = private_key_path if private_key_path is not None else settings.signing_key_path
+    pub_path = public_key_path if public_key_path is not None else settings.public_key_path
+
+    if priv_path.exists():
+        raise FileExistsError(f"Signing key already exists at {priv_path}")
+
+    private_key = ed25519.Ed25519PrivateKey.generate()
+    public_key = private_key.public_key()
+
+    private_pem = private_key.private_bytes(
+        encoding=serialization.Encoding.PEM,
+        format=serialization.PrivateFormat.PKCS8,
+        encryption_algorithm=serialization.NoEncryption(),
+    )
+    public_pem = public_key.public_bytes(
+        encoding=serialization.Encoding.PEM,
+        format=serialization.PublicFormat.SubjectPublicKeyInfo,
+    )
+
+    priv_path.write_bytes(private_pem)
+    pub_path.write_bytes(public_pem)
+
+    # Set permissions to 0600 on POSIX (no-op on Windows)
+    if sys.platform != "win32":
+        os.chmod(priv_path, stat.S_IRUSR | stat.S_IWUSR)
+        os.chmod(pub_path, stat.S_IRUSR | stat.S_IWUSR)
+
+
+def ensure_signing_key_exists() -> None:
+    """Ensure a signing key exists at settings.signing_key_path.
+
+    If missing, generates a new keypair. Safe to call on every tool invocation.
+    """
+    if not settings.signing_key_path.exists():
+        generate_signing_key()
+
+
+def load_signing_key() -> ed25519.Ed25519PrivateKey:
+    """Load the Ed25519 private key from settings.signing_key_path."""
+    pem_bytes = settings.signing_key_path.read_bytes()
+    return serialization.load_pem_private_key(pem_bytes, password=None)  # type: ignore[return-value]
+
+
+def load_public_key() -> ed25519.Ed25519PublicKey:
+    """Load the Ed25519 public key from settings.public_key_path."""
+    pem_bytes = settings.public_key_path.read_bytes()
+    return serialization.load_pem_public_key(pem_bytes)  # type: ignore[return-value]
+
+
+def get_key_id() -> str:
+    """Return a stable key identifier (first 16 hex chars of SHA-256 of public key bytes)."""
+    public_key = load_public_key()
+    raw_bytes = public_key.public_bytes(
+        encoding=serialization.Encoding.Raw,
+        format=serialization.PublicFormat.Raw,
+    )
+    return hashlib.sha256(raw_bytes).hexdigest()[:16]

--- a/src/amr/db/engine.py
+++ b/src/amr/db/engine.py
@@ -51,6 +51,22 @@ CREATE TABLE IF NOT EXISTS mandate_events (
     reason      TEXT NOT NULL DEFAULT ''
 );
 
+CREATE TABLE IF NOT EXISTS issued_tokens (
+    jti              TEXT PRIMARY KEY,
+    mandate_id       TEXT NOT NULL REFERENCES mandates(id),
+    agent_id         TEXT NOT NULL,
+    action_hash      TEXT NOT NULL,
+    scope_digest     TEXT NOT NULL,
+    audience         TEXT NOT NULL,
+    issued_at        TEXT NOT NULL,
+    expires_at       TEXT NOT NULL,
+    key_id           TEXT NOT NULL
+);
+
+CREATE INDEX IF NOT EXISTS idx_issued_tokens_mandate  ON issued_tokens(mandate_id);
+CREATE INDEX IF NOT EXISTS idx_issued_tokens_expires  ON issued_tokens(expires_at);
+CREATE INDEX IF NOT EXISTS idx_issued_tokens_action   ON issued_tokens(mandate_id, action_hash);
+
 CREATE INDEX IF NOT EXISTS idx_mandates_agent_id     ON mandates(agent_id);
 CREATE INDEX IF NOT EXISTS idx_mandates_principal_id ON mandates(principal_id);
 CREATE INDEX IF NOT EXISTS idx_mandates_status       ON mandates(status);
@@ -101,10 +117,11 @@ async def init_db(db_path: Path | str | None = None) -> None:
     async with aiosqlite.connect(str(path)) as db:
         db.row_factory = aiosqlite.Row
         await db.executescript(_SCHEMA_SQL)
-        # Insert schema version if not present
+        # Schema v2: adds issued_tokens table for structural hard-stop enforcement.
+        # Existing v1 DBs are upgraded transparently (CREATE IF NOT EXISTS is idempotent).
         await db.execute(
             "INSERT OR IGNORE INTO schema_version (version) VALUES (?)",
-            (1,),
+            (2,),
         )
         await db.commit()
 
@@ -158,3 +175,70 @@ async def get_last_action_hash(db: aiosqlite.Connection, mandate_id: str) -> str
     if row2 is None:
         return ""
     return row2["chain_hash"]
+
+
+async def record_issued_token(
+    db: aiosqlite.Connection, token_row: dict[str, str]
+) -> None:
+    """Insert a newly issued token into issued_tokens. Does NOT commit.
+
+    The caller is responsible for committing the transaction.
+    Expected keys in token_row: jti, mandate_id, agent_id, action_hash,
+    scope_digest, audience, issued_at, expires_at, key_id.
+    """
+    await db.execute(
+        """
+        INSERT INTO issued_tokens (
+            jti, mandate_id, agent_id, action_hash, scope_digest,
+            audience, issued_at, expires_at, key_id
+        ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)
+        """,
+        (
+            token_row["jti"],
+            token_row["mandate_id"],
+            token_row["agent_id"],
+            token_row["action_hash"],
+            token_row["scope_digest"],
+            token_row["audience"],
+            token_row["issued_at"],
+            token_row["expires_at"],
+            token_row["key_id"],
+        ),
+    )
+
+
+async def is_token_replay(
+    db: aiosqlite.Connection,
+    mandate_id: str,
+    action_hash: str,
+    now_iso: str,
+) -> bool:
+    """Return True if an active (non-expired) token already exists
+    for the given (mandate_id, action_hash) pair.
+    """
+    cursor = await db.execute(
+        """
+        SELECT 1 FROM issued_tokens
+        WHERE mandate_id = ?
+          AND action_hash = ?
+          AND expires_at > ?
+        LIMIT 1
+        """,
+        (mandate_id, action_hash, now_iso),
+    )
+    row = await cursor.fetchone()
+    return row is not None
+
+
+async def get_issued_token(
+    db: aiosqlite.Connection, jti: str
+) -> dict[str, str] | None:
+    """Return the full row of an issued token by its jti, or None if absent."""
+    cursor = await db.execute(
+        "SELECT * FROM issued_tokens WHERE jti = ?",
+        (jti,),
+    )
+    row = await cursor.fetchone()
+    if row is None:
+        return None
+    return dict(row)

--- a/src/amr/models/__init__.py
+++ b/src/amr/models/__init__.py
@@ -1,1 +1,4 @@
 # AMR Models
+from amr.models.token import IssueTokenRequest, TokenDenyResult, TokenIssueResult
+
+__all__ = ["IssueTokenRequest", "TokenDenyResult", "TokenIssueResult"]

--- a/src/amr/models/token.py
+++ b/src/amr/models/token.py
@@ -1,0 +1,39 @@
+"""Pydantic models for action tokens issued by AMR."""
+
+from datetime import datetime
+from uuid import UUID
+
+from pydantic import BaseModel, Field
+
+
+class IssueTokenRequest(BaseModel):
+    """Input for issuing an action token. Strictly validated."""
+
+    model_config = {"extra": "forbid"}
+
+    mandate_id: UUID
+    agent_id: str = Field(..., min_length=1, max_length=200)
+    action: str = Field(..., min_length=1, max_length=2000)
+    audience: str = Field(..., min_length=1, max_length=500)
+    action_metadata: dict[str, str] = Field(default_factory=dict)
+
+
+class TokenIssueResult(BaseModel):
+    """Result of a successful token issuance."""
+
+    token: str
+    jti: UUID
+    expires_at: datetime
+    key_id: str
+
+
+class TokenDenyResult(BaseModel):
+    """Result of a denied token issuance.
+
+    reason is a machine-readable code (e.g. "mandate_not_found",
+    "mandate_expired", "replay_detected_active_token_exists").
+    """
+
+    denied: bool = True
+    reason: str
+    mandate_id: UUID | None = None

--- a/src/amr/server.py
+++ b/src/amr/server.py
@@ -8,6 +8,7 @@ from mcp.server.fastmcp import FastMCP
 from amr.config import settings
 from amr.tools.create_mandate import create_mandate
 from amr.tools.get_proof import get_proof
+from amr.tools.issue_action_token import issue_action_token
 from amr.tools.log_action import log_action
 from amr.tools.verify_mandate import verify_mandate
 
@@ -18,6 +19,7 @@ mcp.tool()(create_mandate)
 mcp.tool()(verify_mandate)
 mcp.tool()(log_action)
 mcp.tool()(get_proof)
+mcp.tool()(issue_action_token)
 
 
 def main() -> None:

--- a/src/amr/tools/issue_action_token.py
+++ b/src/amr/tools/issue_action_token.py
@@ -1,0 +1,224 @@
+"""AMR tool: issue_action_token — structural hard-stop token issuer.
+
+This is the enforcement layer: no valid mandate → no token → no action.
+"""
+
+import hashlib
+import json
+from datetime import UTC, datetime, timedelta
+from uuid import UUID, uuid4
+
+import jwt
+from cryptography.hazmat.primitives import serialization
+from pydantic import ValidationError
+
+from amr.config import settings
+from amr.crypto.signing import ensure_signing_key_exists, get_key_id, load_signing_key
+from amr.db.engine import (
+    get_db,
+    init_db,
+    is_token_replay,
+    record_issued_token,
+)
+from amr.models.token import IssueTokenRequest
+
+
+def _canonical_action_hash(action: str, audience: str, metadata: dict[str, str]) -> str:
+    """Canonical SHA-256 hash of the action descriptor.
+
+    Uses sorted keys and compact separators for reproducibility across
+    languages and implementations. Consumers MUST use the exact same
+    canonicalization when verifying a token.
+    """
+    canonical = json.dumps(
+        {"action": action, "audience": audience, "metadata": metadata},
+        sort_keys=True,
+        separators=(",", ":"),
+    )
+    return hashlib.sha256(canonical.encode("utf-8")).hexdigest()
+
+
+def _scope_digest(scope: str) -> str:
+    """SHA-256 of the mandate scope at issuance time."""
+    return hashlib.sha256(scope.encode("utf-8")).hexdigest()
+
+
+async def issue_action_token(
+    mandate_id: str,
+    agent_id: str,
+    action: str,
+    audience: str,
+    action_metadata_json: str = "{}",
+    lifetime_override_seconds: int | None = None,
+) -> str:
+    """Issue a signed action token IF AND ONLY IF a valid mandate authorizes it.
+
+    This is the hard-stop: no valid mandate → no token → no action possible.
+    Returns a JSON string with either {token, jti, expires_at, key_id}
+    on success, or {denied: true, reason: "...", mandate_id: "..."} on denial.
+
+    Args:
+        mandate_id: UUID of the mandate the agent invokes.
+        agent_id: Agent identifier, must match mandate.agent_id.
+        action: Description of the action to be authorized.
+        audience: Where the token will be presented (runtime/platform URL or id).
+        action_metadata_json: Optional JSON-encoded dict of additional action metadata.
+        lifetime_override_seconds: Optional override for token lifetime.
+            Intended for tests only. If None, uses settings.token_lifetime_seconds.
+
+    Returns:
+        JSON string. Success keys: token, jti, expires_at, key_id.
+        Denial keys: denied (true), reason, mandate_id.
+    """
+    db = None
+    try:
+        # --- 1. Validate inputs via Pydantic ---
+        try:
+            metadata_raw = (
+                json.loads(action_metadata_json) if action_metadata_json else {}
+            )
+            if not isinstance(metadata_raw, dict):
+                return json.dumps({
+                    "denied": True,
+                    "reason": "invalid_input: action_metadata_json must decode to a dict",
+                })
+            req = IssueTokenRequest(
+                mandate_id=UUID(mandate_id),
+                agent_id=agent_id,
+                action=action,
+                audience=audience,
+                action_metadata=metadata_raw,
+            )
+        except (ValidationError, ValueError, json.JSONDecodeError) as exc:
+            return json.dumps({"denied": True, "reason": f"invalid_input: {exc}"})
+
+        # --- 2. Ensure signing key exists (generates on first use) ---
+        ensure_signing_key_exists()
+
+        # --- 3. Fetch mandate and perform hard checks ---
+        now = datetime.now(UTC)
+        await init_db(settings.db_path)
+        db = await get_db(settings.db_path)
+
+        cursor = await db.execute(
+            """
+            SELECT id, agent_id, scope, status, expires_at
+            FROM mandates
+            WHERE id = ?
+            """,
+            (str(req.mandate_id),),
+        )
+        row = await cursor.fetchone()
+
+        if row is None:
+            return json.dumps({
+                "denied": True,
+                "reason": "mandate_not_found",
+                "mandate_id": str(req.mandate_id),
+            })
+
+        if row["agent_id"] != req.agent_id:
+            return json.dumps({
+                "denied": True,
+                "reason": "agent_mismatch",
+                "mandate_id": str(req.mandate_id),
+            })
+
+        if row["status"] != "active":
+            return json.dumps({
+                "denied": True,
+                "reason": f"mandate_status_{row['status']}",
+                "mandate_id": str(req.mandate_id),
+            })
+
+        mandate_expires = datetime.fromisoformat(row["expires_at"])
+        # Ensure timezone awareness (SQLite stores ISO strings; reparse as UTC)
+        if mandate_expires.tzinfo is None:
+            mandate_expires = mandate_expires.replace(tzinfo=UTC)
+        if mandate_expires <= now:
+            return json.dumps({
+                "denied": True,
+                "reason": "mandate_expired",
+                "mandate_id": str(req.mandate_id),
+            })
+
+        # --- 4. Replay prevention ---
+        action_hash = _canonical_action_hash(
+            req.action, req.audience, req.action_metadata
+        )
+        if await is_token_replay(
+            db, str(req.mandate_id), action_hash, now.isoformat()
+        ):
+            return json.dumps({
+                "denied": True,
+                "reason": "replay_detected_active_token_exists",
+                "mandate_id": str(req.mandate_id),
+            })
+
+        # --- 5. Build JWS claims ---
+        jti = uuid4()
+        lifetime = (
+            lifetime_override_seconds
+            if lifetime_override_seconds is not None
+            else settings.token_lifetime_seconds
+        )
+        expires_at = now + timedelta(seconds=lifetime)
+        scope_digest = _scope_digest(row["scope"])
+        key_id = get_key_id()
+
+        claims = {
+            "iss": settings.token_issuer,
+            "sub": req.agent_id,
+            "aud": req.audience,
+            "iat": int(now.timestamp()),
+            "nbf": int(now.timestamp()),
+            "exp": int(expires_at.timestamp()),
+            "jti": str(jti),
+            "amr_mandate_id": str(req.mandate_id),
+            "amr_action_hash": action_hash,
+            "amr_scope_digest": scope_digest,
+        }
+
+        # Load key and serialize to PEM bytes (pyjwt expects bytes or str for EdDSA)
+        private_key = load_signing_key()
+        private_key_pem = private_key.private_bytes(
+            encoding=serialization.Encoding.PEM,
+            format=serialization.PrivateFormat.PKCS8,
+            encryption_algorithm=serialization.NoEncryption(),
+        )
+        token = jwt.encode(
+            claims,
+            private_key_pem,
+            algorithm="EdDSA",
+            headers={"kid": key_id, "typ": "JWT"},
+        )
+
+        # --- 6. Record the issued token (replay prevention + audit) ---
+        await record_issued_token(
+            db,
+            {
+                "jti": str(jti),
+                "mandate_id": str(req.mandate_id),
+                "agent_id": req.agent_id,
+                "action_hash": action_hash,
+                "scope_digest": scope_digest,
+                "audience": req.audience,
+                "issued_at": now.isoformat(),
+                "expires_at": expires_at.isoformat(),
+                "key_id": key_id,
+            },
+        )
+        await db.commit()
+
+        return json.dumps({
+            "token": token,
+            "jti": str(jti),
+            "expires_at": expires_at.isoformat(),
+            "key_id": key_id,
+        })
+
+    except Exception as exc:
+        return json.dumps({"denied": True, "reason": f"internal_error: {exc}"})
+    finally:
+        if db is not None:
+            await db.close()

--- a/tests/_helpers.py
+++ b/tests/_helpers.py
@@ -1,0 +1,58 @@
+"""Test helpers for AMR — direct DB manipulation for isolated test setup."""
+
+from datetime import UTC, datetime, timedelta
+from pathlib import Path
+
+import aiosqlite
+
+from amr.db.engine import init_db
+
+
+async def insert_mandate_directly(
+    db_path: Path,
+    mandate_id: str,
+    principal_id: str = "test-principal",
+    agent_id: str = "test-agent",
+    scope: str = "default scope",
+    status: str = "active",
+    hours_until_expiry: float = 24.0,
+    chain_hash: str = "0" * 64,
+) -> None:
+    """Insert a mandate directly via SQL for isolated test setup.
+
+    Allows negative hours_until_expiry to create already-expired mandates,
+    and allows status="revoked" / "expired" to test denial paths.
+
+    IMPORTANT: this bypasses the production chain_hash invariant. The default
+    chain_hash is a placeholder ("0" * 64). Tests that combine this helper
+    with real chain-dependent operations (e.g. log_action after) may produce
+    broken chains — which is fine for isolated tests of issue_action_token,
+    since that tool does not re-verify the chain. If a test needs a valid
+    chain, use create_mandate() instead.
+    """
+    await init_db(db_path)
+    now = datetime.now(UTC)
+    expires_at = now + timedelta(hours=hours_until_expiry)
+
+    async with aiosqlite.connect(str(db_path)) as db:
+        await db.execute(
+            """
+            INSERT INTO mandates (
+                id, principal_id, agent_id, scope, legal_basis_json,
+                status, created_at, expires_at, metadata_json, chain_hash
+            ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+            """,
+            (
+                mandate_id,
+                principal_id,
+                agent_id,
+                scope,
+                '{"regulation":"test","article":"test","jurisdiction":"EU"}',
+                status,
+                now.isoformat(),
+                expires_at.isoformat(),
+                "{}",
+                chain_hash,
+            ),
+        )
+        await db.commit()

--- a/tests/test_integration_token_flow.py
+++ b/tests/test_integration_token_flow.py
@@ -1,0 +1,152 @@
+"""End-to-end integration test for the token issuance flow.
+
+Scenario: a principal creates a mandate for an agent, the agent requests
+tokens for various actions, some are granted, some are denied.
+"""
+
+import asyncio
+import json
+from pathlib import Path
+from uuid import uuid4
+
+import jwt
+import pytest
+from cryptography.hazmat.primitives import serialization
+
+from amr.crypto.signing import ensure_signing_key_exists, generate_signing_key, load_public_key
+from amr.tools.create_mandate import create_mandate
+from amr.tools.issue_action_token import issue_action_token
+
+
+@pytest.fixture(autouse=True)
+def isolated_signing_keys(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    """Provide isolated Ed25519 key paths for each integration test."""
+    priv = tmp_path / "integ_key.pem"
+    pub = tmp_path / "integ_key.pub"
+    monkeypatch.setattr("amr.config.settings.signing_key_path", priv)
+    monkeypatch.setattr("amr.config.settings.public_key_path", pub)
+    generate_signing_key(priv, pub)
+
+
+@pytest.mark.asyncio
+async def test_end_to_end_token_flow(temp_db: Path) -> None:
+    """Full flow: create mandate → issue token → verify → replay → expire → deny."""
+
+    ensure_signing_key_exists()
+    public_key = load_public_key()
+    public_key_pem = public_key.public_bytes(
+        encoding=serialization.Encoding.PEM,
+        format=serialization.PublicFormat.SubjectPublicKeyInfo,
+    )
+
+    # 1. Create a valid mandate
+    # NOTE: signature of create_mandate is exact — do not rename params.
+    # Verified against src/amr/tools/create_mandate.py at 2026-04-22.
+    create_result_json = await create_mandate(
+        principal_id="hospital-paris-01",
+        agent_id="claude-clinical-v1",
+        scope="summarize patient records for physician review",
+        legal_basis_regulation="EU AI Act",
+        legal_basis_article="Art. 26",
+        duration_hours=24.0,
+        legal_basis_jurisdiction="EU",
+    )
+    create_result = json.loads(create_result_json)
+    assert "mandate_id" in create_result, (
+        f"create_mandate returned unexpected result: {create_result_json}"
+    )
+    mandate_id = create_result["mandate_id"]
+
+    # 2. Issue a token for a valid action
+    issue_result_1 = json.loads(await issue_action_token(
+        mandate_id=mandate_id,
+        agent_id="claude-clinical-v1",
+        action="summarize patient 12345",
+        audience="clinical-runtime://hospital-paris-01",
+        lifetime_override_seconds=2,  # short to test expiry quickly
+    ))
+    assert "token" in issue_result_1, f"token issuance failed: {issue_result_1}"
+    token_1 = issue_result_1["token"]
+
+    # 3. Verify the token offline with the public key
+    decoded = jwt.decode(
+        token_1,
+        public_key_pem,
+        algorithms=["EdDSA"],
+        audience="clinical-runtime://hospital-paris-01",
+    )
+    assert decoded["sub"] == "claude-clinical-v1"
+    assert decoded["amr_mandate_id"] == mandate_id
+    assert "amr_action_hash" in decoded
+
+    # 4. Replay attempt on same action → denied
+    issue_result_2 = json.loads(await issue_action_token(
+        mandate_id=mandate_id,
+        agent_id="claude-clinical-v1",
+        action="summarize patient 12345",
+        audience="clinical-runtime://hospital-paris-01",
+    ))
+    assert issue_result_2.get("denied") is True
+    assert issue_result_2.get("reason") == "replay_detected_active_token_exists"
+
+    # 5. Different action → allowed
+    issue_result_3 = json.loads(await issue_action_token(
+        mandate_id=mandate_id,
+        agent_id="claude-clinical-v1",
+        action="summarize patient 67890",
+        audience="clinical-runtime://hospital-paris-01",
+    ))
+    assert "token" in issue_result_3, f"different-action issuance failed: {issue_result_3}"
+
+    # 6. Wait for token_1 to expire, then re-issue for the same action → allowed
+    await asyncio.sleep(3)
+    issue_result_4 = json.loads(await issue_action_token(
+        mandate_id=mandate_id,
+        agent_id="claude-clinical-v1",
+        action="summarize patient 12345",
+        audience="clinical-runtime://hospital-paris-01",
+    ))
+    assert "token" in issue_result_4, (
+        f"re-issuance after expiry failed: {issue_result_4}"
+    )
+
+    # 7. Audience confusion defense: consumer B refuses token for audience A
+    # token_1 may have expired at this point (lifetime=2s, sleep=3s), so we
+    # disable exp verification to isolate the audience check — the audience
+    # mismatch MUST still be raised even when expiry is ignored.
+    with pytest.raises(jwt.exceptions.InvalidAudienceError):
+        jwt.decode(
+            token_1,
+            public_key_pem,
+            algorithms=["EdDSA"],
+            audience="wrong-runtime://other-hospital",
+            options={"verify_exp": False},
+        )
+
+
+@pytest.mark.asyncio
+async def test_expired_mandate_denies_token(temp_db: Path) -> None:
+    """A mandate whose expires_at is in the past cannot issue new tokens.
+
+    Uses insert_mandate_directly to set up an already-expired mandate
+    without violating the production append-only invariant on real data.
+    """
+    from tests._helpers import insert_mandate_directly
+
+    mandate_id = str(uuid4())
+    await insert_mandate_directly(
+        db_path=temp_db,
+        mandate_id=mandate_id,
+        agent_id="expired-agent",
+        status="active",  # status "active" but expires_at in the past
+        hours_until_expiry=-1.0,
+    )
+
+    result = json.loads(await issue_action_token(
+        mandate_id=mandate_id,
+        agent_id="expired-agent",
+        action="do something",
+        audience="runtime://x",
+    ))
+    assert result.get("denied") is True
+    assert result.get("reason") == "mandate_expired"

--- a/tests/test_issue_action_token.py
+++ b/tests/test_issue_action_token.py
@@ -1,0 +1,281 @@
+"""Tests for the issue_action_token tool — structural hard-stop enforcement."""
+
+import asyncio
+import json
+from pathlib import Path
+from uuid import uuid4
+
+import pytest
+from cryptography.hazmat.primitives import serialization
+
+from amr.crypto.signing import (
+    ensure_signing_key_exists,
+    generate_signing_key,
+    load_public_key,
+)
+from amr.tools.issue_action_token import _canonical_action_hash, issue_action_token
+from tests._helpers import insert_mandate_directly
+
+
+@pytest.fixture(autouse=True)
+def isolated_signing_keys(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    """Provide isolated signing key paths per test."""
+    priv = tmp_path / "test_key.pem"
+    pub = tmp_path / "test_key.pub"
+    monkeypatch.setattr("amr.config.settings.signing_key_path", priv)
+    monkeypatch.setattr("amr.config.settings.public_key_path", pub)
+    generate_signing_key(priv, pub)
+
+
+def _public_key_pem() -> bytes:
+    pub = load_public_key()
+    return pub.public_bytes(
+        encoding=serialization.Encoding.PEM,
+        format=serialization.PublicFormat.SubjectPublicKeyInfo,
+    )
+
+
+async def test_happy_path_issues_valid_token(temp_db: Path) -> None:
+    import jwt as pyjwt
+
+    mandate_id = str(uuid4())
+    await insert_mandate_directly(
+        temp_db,
+        mandate_id,
+        agent_id="happy-agent",
+        scope="test scope",
+    )
+
+    result_json = await issue_action_token(
+        mandate_id=mandate_id,
+        agent_id="happy-agent",
+        action="do the thing",
+        audience="runtime://platform-a",
+    )
+    result = json.loads(result_json)
+    assert "token" in result, f"Expected token in result: {result}"
+
+    decoded = pyjwt.decode(
+        result["token"],
+        _public_key_pem(),
+        algorithms=["EdDSA"],
+        audience="runtime://platform-a",
+    )
+    assert decoded["iss"] == "amr://localhost"
+    assert decoded["sub"] == "happy-agent"
+    assert decoded["aud"] == "runtime://platform-a"
+    assert "iat" in decoded
+    assert "nbf" in decoded
+    assert "exp" in decoded
+    assert "jti" in decoded
+    assert decoded["amr_mandate_id"] == mandate_id
+    assert "amr_action_hash" in decoded
+    assert "amr_scope_digest" in decoded
+
+
+async def test_mandate_not_found_is_denied(temp_db: Path) -> None:
+    result = json.loads(await issue_action_token(
+        mandate_id=str(uuid4()),
+        agent_id="any-agent",
+        action="do something",
+        audience="runtime://x",
+    ))
+    assert result.get("denied") is True
+    assert result.get("reason") == "mandate_not_found"
+
+
+async def test_agent_mismatch_is_denied(temp_db: Path) -> None:
+    mandate_id = str(uuid4())
+    await insert_mandate_directly(temp_db, mandate_id, agent_id="real-agent")
+
+    result = json.loads(await issue_action_token(
+        mandate_id=mandate_id,
+        agent_id="wrong-agent",
+        action="do something",
+        audience="runtime://x",
+    ))
+    assert result.get("denied") is True
+    assert result.get("reason") == "agent_mismatch"
+
+
+async def test_expired_mandate_is_denied(temp_db: Path) -> None:
+    mandate_id = str(uuid4())
+    await insert_mandate_directly(
+        temp_db, mandate_id, agent_id="expired-agent", hours_until_expiry=-1.0
+    )
+
+    result = json.loads(await issue_action_token(
+        mandate_id=mandate_id,
+        agent_id="expired-agent",
+        action="do something",
+        audience="runtime://x",
+    ))
+    assert result.get("denied") is True
+    assert result.get("reason") == "mandate_expired"
+
+
+async def test_revoked_mandate_is_denied(temp_db: Path) -> None:
+    mandate_id = str(uuid4())
+    await insert_mandate_directly(
+        temp_db, mandate_id, agent_id="revoked-agent", status="revoked"
+    )
+
+    result = json.loads(await issue_action_token(
+        mandate_id=mandate_id,
+        agent_id="revoked-agent",
+        action="do something",
+        audience="runtime://x",
+    ))
+    assert result.get("denied") is True
+    assert result.get("reason") == "mandate_status_revoked"
+
+
+async def test_replay_is_denied_when_active_token_exists(temp_db: Path) -> None:
+    mandate_id = str(uuid4())
+    await insert_mandate_directly(temp_db, mandate_id, agent_id="replay-agent")
+
+    # First issuance — should succeed
+    result_a = json.loads(await issue_action_token(
+        mandate_id=mandate_id,
+        agent_id="replay-agent",
+        action="same action",
+        audience="runtime://x",
+    ))
+    assert "token" in result_a, f"First issuance should succeed: {result_a}"
+
+    # Second issuance — same mandate + same action → replay denied
+    result_b = json.loads(await issue_action_token(
+        mandate_id=mandate_id,
+        agent_id="replay-agent",
+        action="same action",
+        audience="runtime://x",
+    ))
+    assert result_b.get("denied") is True
+    assert result_b.get("reason") == "replay_detected_active_token_exists"
+
+
+async def test_replay_allowed_after_previous_token_expired(temp_db: Path) -> None:
+    mandate_id = str(uuid4())
+    await insert_mandate_directly(temp_db, mandate_id, agent_id="replay-expiry-agent")
+
+    # Issue token A with very short lifetime
+    result_a = json.loads(await issue_action_token(
+        mandate_id=mandate_id,
+        agent_id="replay-expiry-agent",
+        action="short-lived action",
+        audience="runtime://x",
+        lifetime_override_seconds=1,
+    ))
+    assert "token" in result_a, f"First issuance should succeed: {result_a}"
+
+    # Wait for expiry
+    await asyncio.sleep(2)
+
+    # Issue token B for same action — should now be allowed
+    result_b = json.loads(await issue_action_token(
+        mandate_id=mandate_id,
+        agent_id="replay-expiry-agent",
+        action="short-lived action",
+        audience="runtime://x",
+    ))
+    assert "token" in result_b, f"Re-issuance after expiry should succeed: {result_b}"
+
+
+async def test_invalid_mandate_id_format_is_denied(temp_db: Path) -> None:
+    result = json.loads(await issue_action_token(
+        mandate_id="not-a-uuid",
+        agent_id="some-agent",
+        action="do something",
+        audience="runtime://x",
+    ))
+    assert result.get("denied") is True
+    assert result.get("reason", "").startswith("invalid_input")
+
+
+async def test_invalid_action_metadata_json_is_denied(temp_db: Path) -> None:
+    result = json.loads(await issue_action_token(
+        mandate_id=str(uuid4()),
+        agent_id="some-agent",
+        action="do something",
+        audience="runtime://x",
+        action_metadata_json="not json",
+    ))
+    assert result.get("denied") is True
+    assert result.get("reason", "").startswith("invalid_input")
+
+
+def test_action_hash_is_deterministic() -> None:
+    args = ("my action", "runtime://x", {"key": "value"})
+    hashes = [_canonical_action_hash(*args) for _ in range(10)]
+    assert len(set(hashes)) == 1, "Hash must be identical across calls"
+
+
+async def test_two_different_actions_produce_different_tokens(temp_db: Path) -> None:
+    mandate_id = str(uuid4())
+    await insert_mandate_directly(temp_db, mandate_id, agent_id="diff-agent")
+
+    result_x = json.loads(await issue_action_token(
+        mandate_id=mandate_id,
+        agent_id="diff-agent",
+        action="action X",
+        audience="runtime://x",
+    ))
+    result_y = json.loads(await issue_action_token(
+        mandate_id=mandate_id,
+        agent_id="diff-agent",
+        action="action Y",
+        audience="runtime://x",
+    ))
+
+    assert "token" in result_x
+    assert "token" in result_y
+
+    hash_x = _canonical_action_hash("action X", "runtime://x", {})
+    hash_y = _canonical_action_hash("action Y", "runtime://x", {})
+    assert hash_x != hash_y
+
+
+async def test_token_signature_verifies_with_public_key(temp_db: Path) -> None:
+    import jwt as pyjwt
+
+    mandate_id = str(uuid4())
+    await insert_mandate_directly(temp_db, mandate_id, agent_id="sig-agent")
+
+    result = json.loads(await issue_action_token(
+        mandate_id=mandate_id,
+        agent_id="sig-agent",
+        action="verify this",
+        audience="runtime://verify",
+    ))
+    assert "token" in result
+
+    # Should not raise
+    pyjwt.decode(
+        result["token"],
+        _public_key_pem(),
+        algorithms=["EdDSA"],
+        audience="runtime://verify",
+    )
+
+
+async def test_audience_claim_matches_input(temp_db: Path) -> None:
+    import jwt as pyjwt
+
+    mandate_id = str(uuid4())
+    await insert_mandate_directly(temp_db, mandate_id, agent_id="aud-agent")
+
+    result = json.loads(await issue_action_token(
+        mandate_id=mandate_id,
+        agent_id="aud-agent",
+        action="some action",
+        audience="runtime://platform-x",
+    ))
+    assert "token" in result
+
+    decoded = pyjwt.decode(
+        result["token"],
+        _public_key_pem(),
+        algorithms=["EdDSA"],
+        audience="runtime://platform-x",
+    )
+    assert decoded["aud"] == "runtime://platform-x"

--- a/tests/test_issued_tokens_db.py
+++ b/tests/test_issued_tokens_db.py
@@ -1,0 +1,195 @@
+"""Tests for issued_tokens DB helpers."""
+
+from datetime import UTC, datetime, timedelta
+from pathlib import Path
+from uuid import uuid4
+
+import aiosqlite
+import pytest
+
+from amr.db.engine import (
+    get_db,
+    get_issued_token,
+    init_db,
+    is_token_replay,
+    record_issued_token,
+)
+
+
+def _future_iso(seconds: int = 300) -> str:
+    return (datetime.now(UTC) + timedelta(seconds=seconds)).isoformat()
+
+
+def _past_iso(seconds: int = 300) -> str:
+    return (datetime.now(UTC) - timedelta(seconds=seconds)).isoformat()
+
+
+def _now_iso() -> str:
+    return datetime.now(UTC).isoformat()
+
+
+def _make_token_row(
+    mandate_id: str,
+    action_hash: str = "deadbeef",
+    jti: str | None = None,
+    expires_at: str | None = None,
+) -> dict[str, str]:
+    return {
+        "jti": jti or str(uuid4()),
+        "mandate_id": mandate_id,
+        "agent_id": "test-agent",
+        "action_hash": action_hash,
+        "scope_digest": "scopehash",
+        "audience": "runtime://test",
+        "issued_at": _now_iso(),
+        "expires_at": expires_at or _future_iso(),
+        "key_id": "abcd1234ef567890",
+    }
+
+
+async def _insert_mandate(db: aiosqlite.Connection, mandate_id: str) -> None:
+    """Insert a minimal mandate row to satisfy FK constraint."""
+    now = datetime.now(UTC).isoformat()
+    expires = (datetime.now(UTC) + timedelta(hours=24)).isoformat()
+    await db.execute(
+        """
+        INSERT INTO mandates (
+            id, principal_id, agent_id, scope, legal_basis_json,
+            status, created_at, expires_at, metadata_json, chain_hash
+        ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+        """,
+        (
+            mandate_id,
+            "principal",
+            "test-agent",
+            "test scope",
+            "{}",
+            "active",
+            now,
+            expires,
+            "{}",
+            "0" * 64,
+        ),
+    )
+    await db.commit()
+
+
+async def test_record_inserts_row(temp_db: Path) -> None:
+    await init_db(temp_db)
+    db = await get_db(temp_db)
+    try:
+        mandate_id = str(uuid4())
+        await _insert_mandate(db, mandate_id)
+        row = _make_token_row(mandate_id)
+        await record_issued_token(db, row)
+        await db.commit()
+        result = await get_issued_token(db, row["jti"])
+    finally:
+        await db.close()
+    assert result is not None
+    assert result["jti"] == row["jti"]
+    assert result["mandate_id"] == mandate_id
+
+
+async def test_replay_detected_on_same_pair(temp_db: Path) -> None:
+    await init_db(temp_db)
+    db = await get_db(temp_db)
+    try:
+        mandate_id = str(uuid4())
+        await _insert_mandate(db, mandate_id)
+        row = _make_token_row(mandate_id, action_hash="action_abc")
+        await record_issued_token(db, row)
+        await db.commit()
+        result = await is_token_replay(db, mandate_id, "action_abc", _now_iso())
+    finally:
+        await db.close()
+    assert result is True
+
+
+async def test_replay_not_detected_after_expiration(temp_db: Path) -> None:
+    await init_db(temp_db)
+    db = await get_db(temp_db)
+    try:
+        mandate_id = str(uuid4())
+        await _insert_mandate(db, mandate_id)
+        # expires_at already in the past
+        row = _make_token_row(mandate_id, action_hash="action_expired", expires_at=_past_iso())
+        await record_issued_token(db, row)
+        await db.commit()
+        result = await is_token_replay(db, mandate_id, "action_expired", _now_iso())
+    finally:
+        await db.close()
+    assert result is False
+
+
+async def test_replay_not_detected_different_action(temp_db: Path) -> None:
+    await init_db(temp_db)
+    db = await get_db(temp_db)
+    try:
+        mandate_id = str(uuid4())
+        await _insert_mandate(db, mandate_id)
+        row = _make_token_row(mandate_id, action_hash="action_A")
+        await record_issued_token(db, row)
+        await db.commit()
+        result = await is_token_replay(db, mandate_id, "action_B", _now_iso())
+    finally:
+        await db.close()
+    assert result is False
+
+
+async def test_replay_not_detected_different_mandate(temp_db: Path) -> None:
+    await init_db(temp_db)
+    db = await get_db(temp_db)
+    try:
+        mandate_id_1 = str(uuid4())
+        mandate_id_2 = str(uuid4())
+        await _insert_mandate(db, mandate_id_1)
+        await _insert_mandate(db, mandate_id_2)
+        row = _make_token_row(mandate_id_1, action_hash="shared_action")
+        await record_issued_token(db, row)
+        await db.commit()
+        result = await is_token_replay(db, mandate_id_2, "shared_action", _now_iso())
+    finally:
+        await db.close()
+    assert result is False
+
+
+async def test_get_issued_token_returns_none_for_unknown_jti(temp_db: Path) -> None:
+    await init_db(temp_db)
+    db = await get_db(temp_db)
+    try:
+        result = await get_issued_token(db, "nonexistent-jti")
+    finally:
+        await db.close()
+    assert result is None
+
+
+async def test_commit_required_for_persistence(temp_db: Path) -> None:
+    """record_issued_token without commit → not visible in a new connection."""
+    await init_db(temp_db)
+    jti = str(uuid4())
+    mandate_id = str(uuid4())
+
+    # Insert mandate in a separate committed connection first
+    db = await get_db(temp_db)
+    try:
+        await _insert_mandate(db, mandate_id)
+    finally:
+        await db.close()
+
+    # Insert token but do NOT commit
+    db2 = await get_db(temp_db)
+    try:
+        row = _make_token_row(mandate_id, jti=jti)
+        await record_issued_token(db2, row)
+        # Intentionally no await db2.commit()
+    finally:
+        await db2.close()
+
+    # Open a new connection and verify the token is not visible
+    db3 = await get_db(temp_db)
+    try:
+        result = await get_issued_token(db3, jti)
+    finally:
+        await db3.close()
+    assert result is None

--- a/tests/test_signing.py
+++ b/tests/test_signing.py
@@ -1,0 +1,103 @@
+"""Tests for AMR Ed25519 signing key management."""
+
+import sys
+from pathlib import Path
+
+import pytest
+from cryptography.hazmat.primitives.asymmetric import ed25519
+
+from amr.crypto.signing import (
+    ensure_signing_key_exists,
+    generate_signing_key,
+    get_key_id,
+    load_public_key,
+    load_signing_key,
+)
+
+
+@pytest.fixture()
+def key_paths(tmp_path: Path, monkeypatch: pytest.MonkeyPatch):
+    """Provide isolated key paths for each test."""
+    priv = tmp_path / "test_signing_key.pem"
+    pub = tmp_path / "test_signing_key.pub"
+    monkeypatch.setattr("amr.config.settings.signing_key_path", priv)
+    monkeypatch.setattr("amr.config.settings.public_key_path", pub)
+    return priv, pub
+
+
+def test_generate_creates_both_files(key_paths):
+    priv, pub = key_paths
+    generate_signing_key(priv, pub)
+    assert priv.exists(), "Private key file should exist after generation"
+    assert pub.exists(), "Public key file should exist after generation"
+
+
+def test_generate_refuses_overwrite(key_paths):
+    priv, pub = key_paths
+    generate_signing_key(priv, pub)
+    with pytest.raises(FileExistsError):
+        generate_signing_key(priv, pub)
+
+
+def test_ensure_creates_if_missing(key_paths):
+    priv, pub = key_paths
+    assert not priv.exists()
+    ensure_signing_key_exists()
+    assert priv.exists()
+    assert pub.exists()
+
+
+def test_ensure_idempotent(key_paths):
+    priv, pub = key_paths
+    ensure_signing_key_exists()
+    mtime = priv.stat().st_mtime
+    ensure_signing_key_exists()
+    assert priv.stat().st_mtime == mtime, "ensure_signing_key_exists should not overwrite existing key"
+
+
+def test_load_returns_ed25519_private(key_paths):
+    priv, pub = key_paths
+    generate_signing_key(priv, pub)
+    key = load_signing_key()
+    assert isinstance(key, ed25519.Ed25519PrivateKey)
+
+
+def test_load_public_returns_ed25519_public(key_paths):
+    priv, pub = key_paths
+    generate_signing_key(priv, pub)
+    key = load_public_key()
+    assert isinstance(key, ed25519.Ed25519PublicKey)
+
+
+def test_sign_and_verify_roundtrip(key_paths):
+    priv, pub = key_paths
+    generate_signing_key(priv, pub)
+    private_key = load_signing_key()
+    public_key = load_public_key()
+    message = b"test message for signing"
+    signature = private_key.sign(message)
+    # verify() raises InvalidSignature if wrong; no exception means success
+    public_key.verify(signature, message)
+
+
+def test_get_key_id_is_stable(key_paths):
+    priv, pub = key_paths
+    generate_signing_key(priv, pub)
+    ids = [get_key_id() for _ in range(10)]
+    assert len(set(ids)) == 1, "get_key_id should return the same value on repeated calls"
+
+
+def test_get_key_id_is_16_chars(key_paths):
+    priv, pub = key_paths
+    generate_signing_key(priv, pub)
+    assert len(get_key_id()) == 16
+
+
+@pytest.mark.skipif(sys.platform == "win32", reason="POSIX file permissions not applicable on Windows")
+def test_posix_permissions_0600(key_paths):
+    import stat
+
+    priv, pub = key_paths
+    generate_signing_key(priv, pub)
+    priv_mode = stat.S_IMODE(priv.stat().st_mode)
+    assert priv_mode == 0o600, f"Expected 0o600, got {oct(priv_mode)}"

--- a/tests/test_token_models.py
+++ b/tests/test_token_models.py
@@ -1,0 +1,77 @@
+"""Tests for AMR token Pydantic models."""
+
+import json
+from uuid import uuid4
+
+import pytest
+from pydantic import ValidationError
+
+from amr.models.token import IssueTokenRequest, TokenIssueResult
+
+
+def test_issue_token_request_valid() -> None:
+    req = IssueTokenRequest(
+        mandate_id=uuid4(),
+        agent_id="test-agent",
+        action="do something useful",
+        audience="runtime://platform-x",
+    )
+    assert req.agent_id == "test-agent"
+    assert req.action_metadata == {}
+
+
+def test_issue_token_request_rejects_extra_field() -> None:
+    with pytest.raises(ValidationError):
+        IssueTokenRequest(
+            mandate_id=uuid4(),
+            agent_id="test-agent",
+            action="do something",
+            audience="runtime://x",
+            foo="bar",  # type: ignore[call-arg]
+        )
+
+
+def test_issue_token_request_rejects_invalid_uuid() -> None:
+    with pytest.raises(ValidationError):
+        IssueTokenRequest(
+            mandate_id="not-a-uuid",  # type: ignore[arg-type]
+            agent_id="test-agent",
+            action="do something",
+            audience="runtime://x",
+        )
+
+
+def test_issue_token_request_rejects_empty_agent_id() -> None:
+    with pytest.raises(ValidationError):
+        IssueTokenRequest(
+            mandate_id=uuid4(),
+            agent_id="",
+            action="do something",
+            audience="runtime://x",
+        )
+
+
+def test_issue_token_request_rejects_too_long_action() -> None:
+    with pytest.raises(ValidationError):
+        IssueTokenRequest(
+            mandate_id=uuid4(),
+            agent_id="test-agent",
+            action="x" * 2001,
+            audience="runtime://x",
+        )
+
+
+def test_token_issue_result_roundtrip() -> None:
+    from datetime import UTC, datetime
+
+    original = TokenIssueResult(
+        token="header.payload.signature",
+        jti=uuid4(),
+        expires_at=datetime.now(UTC),
+        key_id="abcd1234ef567890",
+    )
+    serialized = original.model_dump_json()
+    loaded = TokenIssueResult.model_validate(json.loads(serialized))
+    assert loaded.token == original.token
+    assert loaded.jti == original.jti
+    assert loaded.key_id == original.key_id

--- a/uv.lock
+++ b/uv.lock
@@ -17,9 +17,11 @@ version = "0.1.0"
 source = { editable = "." }
 dependencies = [
     { name = "aiosqlite" },
+    { name = "cryptography" },
     { name = "mcp", extra = ["cli"] },
     { name = "pydantic" },
     { name = "pydantic-settings" },
+    { name = "pyjwt", extra = ["crypto"] },
 ]
 
 [package.optional-dependencies]
@@ -32,9 +34,11 @@ dev = [
 [package.metadata]
 requires-dist = [
     { name = "aiosqlite", specifier = ">=0.20.0" },
+    { name = "cryptography", specifier = ">=42.0.0" },
     { name = "mcp", extras = ["cli"], specifier = ">=1.2.0" },
     { name = "pydantic", specifier = ">=2.7.0" },
     { name = "pydantic-settings", specifier = ">=2.3.0" },
+    { name = "pyjwt", extras = ["crypto"], specifier = ">=2.8.0" },
     { name = "pytest", marker = "extra == 'dev'", specifier = ">=8.0.0" },
     { name = "pytest-asyncio", marker = "extra == 'dev'", specifier = ">=0.23.0" },
     { name = "ruff", marker = "extra == 'dev'", specifier = ">=0.4.0" },


### PR DESCRIPTION
## Motivation
Feedback design partner (Adnan Khan, Equinix, 17/04/2026) : le verify_mandate actuel est passif. Cette PR ajoute la couche d'émission de token qui rend l'enforcement structurel : pas de mandat valide = pas de token = pas d'action.

## Changes
- New MCP tool: `issue_action_token`
- New module: `src/amr/crypto/signing.py` (Ed25519 key management)
- New module: `src/amr/models/token.py` (Pydantic v2)
- New DB table: `issued_tokens` (replay prevention + audit trail)
- New dependencies: `cryptography>=42.0.0`, `pyjwt[crypto]>=2.8.0`
- Documentation: `CLAUDE.md`, `README.md`, `docs/token-issuance-spec.md` updated
- Tests: +30 unit tests, +2 integration tests (all green)

## Testing
- `uv run pytest -v` — all green (existing + new)
- `uv run ruff check src/` — clean

## Security considerations
- EdDSA algorithm is hardcoded in encode and decode (no algorithm negotiation)
- Audience claim `aud` is required and MUST be verified by consumers
- Replay prevention via `issued_tokens` table indexed on `(mandate_id, action_hash)`
- Private key file permissions: 0600 on POSIX, generated on first use
- Private key path is in `.gitignore`

## Non-goals of this PR (documented as follow-ups)
- Key rotation (v2)
- Token revocation before expiration (v2)
- Well-known public key distribution endpoint (v2)
- Rate limiting of token issuance (v2)

## Review checklist for human reviewer
- [ ] JWT claims are exhaustive (iss, sub, aud, iat, nbf, exp, jti, amr_*)
- [ ] Replay detection works (test_replay_is_denied + integration)
- [ ] Locked files unchanged
- [ ] Secrets (private key) excluded from git (.gitignore verified)
- [ ] SQL is 100% parameterized (ruff S608 passes)
- [ ] Audience confusion defense in place (test_end_to_end covers it)

## Post-merge recommended action
Budget 200-300 EUR for a 2-3h security audit by a senior Python/crypto freelance dev before the first paying customer uses this in production.