### PR TITLE
[Tracker 2026-05-01] 0 slots libérés, 1 canaux alt signalés, 1 alertes EN COURS HUMAIN, 0 rappels PROPOSÉ

### DIFF
--- a/outreach/pipeline.md
+++ b/outreach/pipeline.md
@@ -177,12 +177,15 @@ Ces noms sont connus via l'autoreply institutionnel de Stefanini. **NE JAMAIS le
 
 **Outreach Radar W18** : **N'A PAS TOURNÉ ce matin** (anomalie cron à investiguer dans repo amr).
 
-**Reply Tracker W18** : tourné chaque matin (PR #15 du 27/04). Mais alertes basées sur pipeline.md gelé au 24/04 → désynchro corrigée par cette mise à jour.
+**Reply Tracker W18** : tourné chaque matin (PR #15 du 27/04). Mais alertes basées sur pipeline.md gelé au 24/04 → désynchro corrigée par mise à jour v5.0.
+
+**Tracker run 2026-05-01** : 0 slot libéré, 1 canal alt signalé (Chift/Henroz, silence LinkedIn 17j), 1 alerte EN COURS HUMAIN (Adnan Khan, 4j sans MAJ post-pivot). Stefanini exclu (autoreply documenté retour 04/05). Aucun changement de statut appliqué. Désynchro pipeline >48h détectée (dernier commit 27/04 20:37 UTC).
 
 ---
 
 ## Changelog pipeline
 
+- **2026-05-01 (Tracker run quotidien)** : note de run — 0 slot libéré, 1 canal alt signalé (Chift/Henroz silence LinkedIn 17j), 1 alerte EN COURS HUMAIN (Adnan 4j sans MAJ post-pivot). Pas de changement de statut appliqué. Avertissement désynchro pipeline (>48h sans commit) émis.
 - **2026-04-27 soir (v5.0)** : SYNCHRO MAJEURE. +13 contacts envoyés depuis le 26/04 (Polu, G'sell, Salathé, Balagué, Iteanu, Strubel, Bouverot, Cédric O, d'Agrain, Krim, Distinguin, Hubert, Sportisse) intégrés. Adnan passé à dernier échange = 27/04 (continuité post-pivot envoyée). Funnel passe de 8 à 21 contacts actifs. Ajout règle synchro pipeline + workflow drift detector. Auteur : Audric via session Claude Opus du 27/04 19h45.
 - **2026-04-24 soir (v4.1)** : autoreply Stefanini reçu (congés jusqu'au 30/04, retour 04/05). Backups Toubiana/Della-Valle notés mais NE PAS solliciter.
 - **2026-04-24 matin (v4)** : réponse Stefanini LinkedIn 08:39 → bascule email institutionnel.


### PR DESCRIPTION
> ⚠️ **AVERTISSEMENT DÉSYNCHRO PIPELINE** ⚠️
>
> `outreach/pipeline.md` n'a pas été mis à jour depuis **80 heures**
> (dernier commit : 2026-04-27 20:37 UTC, par JC7333).
>
> Les alertes ci-dessous peuvent être basées sur des données obsolètes :
> - des envois récents peuvent ne pas figurer dans le pipeline
> - certaines alertes EN COURS HUMAIN peuvent porter sur des contacts
>   déjà relancés en dehors de Claude Code
> - le compteur de slots actifs peut être faux
>
> **Action prioritaire avant d'agir sur ce rapport** :
> synchroniser `outreach/pipeline.md` avec l'état réel des envois
> (LinkedIn, email, etc.) puis re-déclencher ce tracker.

**Date du run** : 2026-05-01

**Slots libérés** : aucun (silence max actuel = 17j sur Henroz/Chift, sous le seuil 35j).

**Canaux alternatifs signalés** :
- 💡 CANAL ALT — Gauthier Henroz (Chift) silence LinkedIn 17j depuis 2026-04-14. Email probable : `gauthier.henroz@chift.eu` (61,8% Hunter à valider). Tenter UNE fois par email ou passer SLOT LIBÉRÉ. À valider avec Hunter.io avant envoi. (Le pipeline indiquait déjà un envoi prévu 28/04 — vérifier si fait.)

**Alertes EN COURS HUMAIN** :
- ⚠️ ATTENTION — Adnan Khan en EN COURS HUMAIN depuis 4 jours sans action visible (continuité post-pivot envoyée 27/04, attente nouvelle réponse). Vérifier fil de discussion LinkedIn.
- (Rémi Stefanini CNIL : silence 7j MAIS autoreply documenté congés jusqu'au 30/04, retour 04/05 — pas d'alerte, fenêtre normale.)

**Rappels PROPOSÉ** : aucun (pas de contact en statut PROPOSÉ).

**Verdict action #1 d'Audric aujourd'hui** : vérifier/finaliser l'envoi email Chift à Gauthier Henroz (canal alt prévu 28/04). Si non fait, l'envoyer aujourd'hui depuis `audric@mandatia.eu` vers `gauthier.henroz@chift.eu` après validation Hunter.io. Ensuite, vérifier le fil LinkedIn Adnan Khan.


---
_Generated by [Claude Code](https://claude.ai/code/session_01RvrbRjMsKgxQiGs5neeZ2M)_