### PR TITLE
weekly-pulse v3 (veille auto)

### DIFF
--- a/.github/scripts/weekly_pulse.py
+++ b/.github/scripts/weekly_pulse.py
@@ -1,18 +1,20 @@
 #!/usr/bin/env python3
 """
-weekly_pulse.py â€” Routine 5 AMR (v2 robuste).
+weekly_pulse.py â€” Routine 5 AMR (v3 avec veille auto).
 
 Tourne tous les dimanches Ã  19h Paris.
-Compile l'Ã©tat de la semaine Ã©coulÃ©e sur le repo amr et appelle Claude pour
-produire une revue hebdo structurÃ©e.
+Compile l'Ã©tat de la semaine + gÃ©nÃ¨re une revue ET une veille AMR via
+web_search natif Anthropic.
 
 Sortie : weekly-pulse/YYYY-MM-DD.md uploadÃ© en artifact GitHub.
 
-Robustesse v2 :
-- Retry exponentiel sur appels HTTP/API (3 tentatives, backoff 1s/2s/4s).
-- Logging structurÃ© (stderr) pour debug.
-- Fallback : si une source de donnÃ©es Ã©choue, on continue avec les autres.
-- Code de sortie 1 uniquement si Claude API totalement KO (sinon 0 mÃªme partiel).
+v3 nouveautÃ©s :
+- web_search activÃ© cÃ´tÃ© Anthropic API (server-side, gÃ©rÃ© par Claude)
+- Veille auto sur concurrents, rÃ©glementaire, marchÃ© AI compliance
+- Section "ðŸ”­ Veille AMR cette semaine" ajoutÃ©e au pulse
+- max_tokens augmentÃ© Ã  4000 (vs 2000 v2)
+
+CoÃ»t marginal : ~0,1â‚¬/sem (web_search + tokens). 5â‚¬/an total.
 """
 
 import os
@@ -64,7 +66,7 @@ def retry_http(fn, *args, retries: int = 3, **kwargs) -> Any:
     return None
 
 
-# â”€â”€â”€ Collecte des donnÃ©es (chaque source fallback si KO) â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€
+# â”€â”€â”€ Collecte des donnÃ©es â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€
 
 def get_recent_commits(days: int = 7) -> list[dict]:
     """Liste les commits des N derniers jours sur main."""
@@ -153,7 +155,7 @@ def get_decisions_md() -> str:
             return p.read_text(encoding="utf-8")[:3000]
     except Exception as e:
         log("WARN", f"Cannot read decisions.md: {e}")
-    return "(decisions.md absent â€” skill decision-log non encore utilisÃ©)"
+    return "(decisions.md absent)"
 
 
 def days_to_bank_window() -> int:
@@ -162,12 +164,38 @@ def days_to_bank_window() -> int:
     return (deadline - dt.date.today()).days
 
 
-# â”€â”€â”€ Prompt Claude â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€
+# â”€â”€â”€ Prompt Claude (v3 avec veille) â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€
 
 SYSTEM_PROMPT = """Tu gÃ©nÃ¨res la revue hebdomadaire d'Audric, mÃ©decin
 thermaliste Ã  Aix-les-Bains, solo fondateur multi-projets.
 
-Format STRICT, dense, lecture 90 secondes max, en franÃ§ais.
+Audric construit AMR (mandatia.eu) = registre de mandats pour agents IA
+basÃ© sur Art.1984 Code civil + eIDAS 2.0 + EU AI Act. ModÃ¨le freemium :
+Tier 0 OSS, Tier 1 350â‚¬/mois (token issuer mandate-gated), Tier 2
+enterprise 20-80k/an, Tier 3 templates sectoriels 2-5kâ‚¬/pack.
+
+STRATÃ‰GIE OPTIONALITÃ‰ : Audric continue la mÃ©decine (rente), dÃ©veloppe
+AMR intensivement, basculera vers AMR plein temps SI signaux d'attraction
+forte se dÃ©clenchent. Signaux Ã  surveiller :
+- ðŸŸ¡ >3 inbounds qualifiÃ©s/mois sans outreach actif
+- ðŸŸ¡ 1er client Tier 1 signÃ© (350â‚¬/mois ARR)
+- ðŸ”´ 1er contrat Tier 2 enterprise 20-80kâ‚¬/an
+- ðŸ”´ ARR rÃ©current 100kâ‚¬ confirmÃ©
+- ðŸš¨ Offre rachat >2Mâ‚¬
+- ðŸš¨ LevÃ©e preempt VC tier 1 sans dÃ©marche
+
+Tu DOIS utiliser web_search pour faire de la veille concurrentielle et
+rÃ©glementaire AMR. Recherches ciblÃ©es obligatoires AVANT de gÃ©nÃ©rer
+la section "ðŸ”­ Veille AMR cette semaine" :
+1. "ArkForge AI compliance" (derniÃ¨re semaine)
+2. "OpenBox AI agent runtime" OR "RAMS blockchain mandate"
+3. "Vanta OneTrust Drata AI agent" (concurrence indirecte)
+4. "EU AI Act Digital Omnibus" (rÃ©glementaire derniÃ¨re semaine)
+5. "AI agent compliance startup funding" (levÃ©es/acquisitions)
+6. "MCP Model Context Protocol mandate authorization" (signaux Ã©cosystÃ¨me)
+7. Une recherche libre selon ce qui semble pertinent cette semaine
+
+Format STRICT, dense, lecture <3 minutes, en franÃ§ais.
 
 Structure de sortie (markdown) :
 
@@ -175,24 +203,51 @@ Structure de sortie (markdown) :
 
 ## ðŸ“Š Semaine Ã©coulÃ©e
 Pour chaque projet actif avec activitÃ© : 1-2 lignes factuelles, chiffrÃ©es.
+Si pas d'activitÃ© sur un projet, NE PAS le mentionner.
 
 ## ðŸŽ¯ Ã‰tat des fronts
 Pour chacun des 5 fronts (AMR, KORVEX, Ã‰tuve, immo, fenÃªtre bancaire) :
-- ðŸ”´ BLOQUANTE (J+7) : [action]
+- ðŸ”´ BLOQUANTE (J+7) : [action] (ne mettre que si vraiment bloquante)
 - ðŸŸ¡ CRITIQUE (J+14) : [action]
 - ðŸŸ¢ UTILE (J+30) : [action]
+Si rien ne bloque sur un front, Ã©crire "RAS" et passer.
+
+## ðŸ”­ Veille AMR cette semaine
+**Concurrents**
+- [Concurrent] : [ce qui a bougÃ©] â†’ impact AMR : [phrase courte dÃ©cisionnelle]
+**RÃ©glementaire**
+- [Ã‰tape AI Act / Digital Omnibus] â†’ impact AMR : [...]
+**MarchÃ©**
+- [LevÃ©e/acquisition/lancement notable] â†’ impact AMR : [...]
+**Signaux faibles Ã  surveiller**
+- [Ã€ garder Ã  l'Å“il sans agir maintenant]
+
+Si une recherche ne ramÃ¨ne rien de nouveau, Ã©crire "RAS cette semaine"
+pour cette sous-section. Ne pas inventer.
+
+## âš¡ Check signaux de bascule AMR
+Ã‰tat courant des 6 signaux :
+- ðŸŸ¡ Inbounds qualifiÃ©s (>3/mois) : [N actuel / 3]
+- ðŸŸ¡ 1er Tier 1 signÃ© : [oui/non]
+- ðŸ”´ 1er Tier 2 enterprise : [oui/non]
+- ðŸ”´ ARR 100k confirmÃ© : [oui/non]
+- ðŸš¨ Offre rachat >2Mâ‚¬ : [oui/non]
+- ðŸš¨ LevÃ©e preempt : [oui/non]
+Si UN signal franchi â†’ Ã©crire en gras "âš ï¸ REVUE STRATÃ‰GIQUE DÃ‰CLENCHÃ‰E".
 
 ## ðŸ“… Plan semaine prochaine
 Calendrier crÃ©neaux soir/WE. Audric consulte en journÃ©e.
+Allocation cible AMR ~9-11h/sem : lun/mer/ven soir 21-23h + sam matin 9-12h + dim flex.
 
 ## â° FenÃªtre bancaire
-J-{days} avant 30/11/2026. Ã‰tapes manquantes cochÃ©es. Action cette semaine.
+J-{days} avant 30/11/2026. Ã‰tape la plus en retard. Action cette semaine si urgente.
 
 ## â“ Sanity check
-UNE seule question d'arbitrage Ã  la fin.
+UNE seule question d'arbitrage Ã  la fin (ou rien si rien d'urgent).
 
 INTERDITS : prÃ©ambules, fÃ©licitations, blabla, listes dÃ©coratives,
-re-stratÃ©gie globale, reproches moraux. Style oral, asymÃ©trique."""
+re-stratÃ©gie globale, reproches moraux. Style oral, asymÃ©trique.
+JAMAIS inventer de fait. Si web_search ne ramÃ¨ne rien, dire "RAS"."""
 
 
 def build_user_prompt(commits, prs, pipeline, decisions, j_bank) -> str:
@@ -214,20 +269,32 @@ DECISIONS.MD ACTUEL :
 
 FENÃŠTRE BANCAIRE : J-{j_bank} avant 30/11/2026.
 
-GÃ©nÃ¨re la revue maintenant. Sortie markdown brute, pas de prÃ©ambule."""
+INSTRUCTIONS :
+1. Effectue les 6-7 recherches web obligatoires pour la section Veille.
+2. GÃ©nÃ¨re ensuite la pulse complÃ¨te au format demandÃ©.
+3. Sortie markdown brute, pas de prÃ©ambule."""
 
 
 def call_claude_with_retry(client, system, user_prompt, retries: int = 3) -> str | None:
-    """Appel Claude avec retry sur erreurs API. None si tout Ã©choue."""
+    """Appel Claude avec web_search + retry sur erreurs API."""
     last_exc = None
     for attempt in range(retries):
         try:
             resp = client.messages.create(
                 model=ANTHROPIC_MODEL,
-                max_tokens=2000,
+                max_tokens=4000,
                 system=system,
+                tools=[
+                    {
+                        "type": "web_search_20250305",
+                        "name": "web_search",
+                        "max_uses": 8,  # Limite hard pour Ã©viter dÃ©rapage coÃ»t
+                    }
+                ],
                 messages=[{"role": "user", "content": user_prompt}],
             )
+            # Server-side tool : Claude gÃ¨re lui-mÃªme les itÃ©rations.
+            # On extrait uniquement les blocks de type "text" du rÃ©sultat final.
             return "".join(b.text for b in resp.content if b.type == "text")
         except (anthropic.APIError, anthropic.APIConnectionError) as e:
             last_exc = e
@@ -244,7 +311,7 @@ def call_claude_with_retry(client, system, user_prompt, retries: int = 3) -> str
 # â”€â”€â”€ Main â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€
 
 def main() -> int:
-    log("INFO", "Starting weekly-pulse")
+    log("INFO", "Starting weekly-pulse v3")
 
     log("INFO", "Collecting dataâ€¦")
     commits = get_recent_commits()
@@ -254,7 +321,7 @@ def main() -> int:
     j_bank = days_to_bank_window()
     log("INFO", f"Collected: {len(commits)} commits, {len(prs)} PRs, J-{j_bank} bank")
 
-    log("INFO", "Calling Claudeâ€¦")
+    log("INFO", "Calling Claude with web_searchâ€¦")
     client = anthropic.Anthropic(api_key=ANTHROPIC_KEY)
     pulse_md = call_claude_with_retry(
         client, SYSTEM_PROMPT, build_user_prompt(commits, prs, pipeline, decisions, j_bank)
@@ -264,7 +331,7 @@ def main() -> int:
         log("ERROR", "Claude API totally down â€” writing fallback")
         pulse_md = f"""# Weekly Pulse â€” {dt.date.today().isoformat()} (FALLBACK)
 
-**âš ï¸ Claude API indisponible. DonnÃ©es brutes ci-dessous, Ã  interprÃ©ter manuellement.**
+**âš ï¸ Claude API indisponible. DonnÃ©es brutes ci-dessous.**
 
 ## Commits 7j
 {json.dumps(commits, indent=2, ensure_ascii=False)}
@@ -278,11 +345,10 @@ J-{j_bank} avant 30/11/2026.
 ## Pipeline (extrait)
 {pipeline[:1500]}
 """
-        # On Ã©crit quand mÃªme un fichier pour que l'artifact ne soit pas vide
         OUTPUT_DIR.mkdir(exist_ok=True)
         out = OUTPUT_DIR / f"{dt.date.today().isoformat()}-FALLBACK.md"
         out.write_text(pulse_md, encoding="utf-8")
-        return 1  # Exit 1 pour signaler l'Ã©chec partiel
+        return 1
 
     log("INFO", "Writing outputâ€¦")
     OUTPUT_DIR.mkdir(exist_ok=True)


### PR DESCRIPTION
Integre web_search natif Anthropic pour veille concurrentielle/reglementaire/marche. Section Veille AMR + check 6 signaux bascule ajoutes au pulse.