### PR TITLE
weekly-pulse v4.1 (fixes)

### DIFF
--- a/.github/scripts/weekly_pulse.py
+++ b/.github/scripts/weekly_pulse.py
@@ -1,6 +1,6 @@
 #!/usr/bin/env python3
 """
-weekly_pulse.py â€” Routine 5 AMR (v4 avec cross-checking et envoi mail).
+weekly_pulse.py â€” Routine 5 AMR (v4.1 â€” fix encoding UTF-8 + max_tokens).
 
 Tourne tous les dimanches Ã  9h Paris.
 Compile l'Ã©tat de la semaine + gÃ©nÃ¨re revue ET veille AMR via web_search
@@ -10,6 +10,11 @@ Sortie :
 - artifact GitHub (backup, accessible depuis Actions)
 - mail HTML Ã  audric9@gmail.com
 - summary GitHub Actions (pour debug)
+
+v4.1 fixes (par rapport Ã  v4) :
+- Encoding UTF-8 explicite sur Subject/From (fini les "Ã°Å¸Å¸Â¢" mojibake)
+- max_tokens 4500 â†’ 8000 (fini les pulses tronquÃ©s mi-phrase)
+- Le reste inchangÃ© : cross-checking + envoi mail + alert level
 
 v4 nouveautÃ©s :
 - Cross-checking obligatoire : 2 sources MINIMUM par fait, sinon marquage "âš ï¸ Ã€ VÃ‰RIFIER"
@@ -31,6 +36,8 @@ from pathlib import Path
 from typing import Any
 from email.mime.text import MIMEText
 from email.mime.multipart import MIMEMultipart
+from email.header import Header
+from email.utils import formataddr
 
 import anthropic
 import requests
@@ -331,7 +338,7 @@ def call_claude_with_retry(client, system, user_prompt, retries: int = 3) -> str
         try:
             resp = client.messages.create(
                 model=ANTHROPIC_MODEL,
-                max_tokens=4500,
+                max_tokens=8000,
                 system=system,
                 tools=[{
                     "type": "web_search_20250305",
@@ -447,8 +454,9 @@ def send_mail(pulse_md: str, alert_level: str) -> bool:
     subject = f"{alert_level} Pulse AMR â€” {today}"
 
     msg = MIMEMultipart("alternative")
-    msg["Subject"] = subject
-    msg["From"] = f"{MAIL_FROM_NAME} <{GMAIL_USER}>"
+    # Encodage UTF-8 explicite pour subject et From (sinon Gmail affiche mojibake)
+    msg["Subject"] = Header(subject, "utf-8")
+    msg["From"] = formataddr((str(Header(MAIL_FROM_NAME, "utf-8")), GMAIL_USER))
     msg["To"] = MAIL_TO
 
     text_part = MIMEText(pulse_md, "plain", "utf-8")

--- a/.github/workflows/weekly-pulse.yml
+++ b/.github/workflows/weekly-pulse.yml
@@ -1,28 +1,27 @@
 name: weekly-pulse
 
 # Routine 5 d'Audric â€” revue hebdo automatique dimanche 9h Paris.
-# GÃ©nÃ¨re pulse avec veille auto + cross-checking, l'envoie par mail.
+# v4.1 : fix encoding UTF-8 + max_tokens + Node 24 forcÃ©.
 #
 # Secrets requis :
-#   - ANTHROPIC_API_KEY : clÃ© API Anthropic (existant)
-#   - GMAIL_APP_PASSWORD : mot de passe d'application Gmail (Ã  crÃ©er)
-#
-# Optionnel :
-#   - GMAIL_USER : adresse Gmail (dÃ©faut: audric9@gmail.com)
+#   - ANTHROPIC_API_KEY : clÃ© API Anthropic
+#   - GMAIL_USER : adresse Gmail (audric9@gmail.com)
+#   - GMAIL_APP_PASSWORD : mot de passe d'application Gmail
 #
 # Timing :
-#   - 0 7 * * 0 = dimanche 7h UTC = 9h Paris en Ã©tÃ© (UTC+2)
-#   - 0 8 * * 0 = dimanche 8h UTC = 9h Paris en hiver (UTC+1)
-#   GitHub Actions ne fait pas la conversion DST automatiquement,
-#   donc on configure les deux crons et le job s'exÃ©cute UNE fois selon le mois.
-#   En pratique le runner tournera 2 fois en heure-pivot (mars/octobre),
-#   mais l'idempotence du pulse (artifact + mail) supporte Ã§a.
+#   - 0 7 * * 0 = dimanche 7h UTC = 9h Paris en Ã©tÃ©
+#   - 0 8 * * 0 = dimanche 8h UTC = 9h Paris en hiver
+#   Le job s'exÃ©cute UNE fois selon le mois (cron natif sans DST).
 
 on:
   schedule:
-    - cron: '0 7 * * 0'  # dimanche 9h Paris (Ã©tÃ©)
-    - cron: '0 8 * * 0'  # dimanche 9h Paris (hiver)
-  workflow_dispatch:  # dÃ©clenchement manuel possible
+    - cron: '0 7 * * 0'
+    - cron: '0 8 * * 0'
+  workflow_dispatch:
+
+# Forcer Node 24 dÃ¨s maintenant (anticipation deprecation 2 juin 2026)
+env:
+  FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: 'true'
 
 jobs:
   weekly-pulse:


### PR DESCRIPTION
Fixes : (1) encoding UTF-8 explicite Subject/From mail (fini les mojibake), (2) max_tokens 4500->8000 (fini les pulses tronques mi-phrase), (3) Node 24 force en avance (fini le warning deprecation). Aucun changement fonctionnel.